### PR TITLE
Suppression du double paint de la page au premier chargement

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -66,7 +66,11 @@ export default {
     }
   },
   created() {
-    this.persons = this.filterPersons(this.$store.state.currentSearch)
+    // si on vient d'une autre page, filtrer les profils en fonction
+    // de la recherche en cours, si il y en a une.
+    if (this.$store.state.currentSearch.trim()) {
+      this.persons = this.filterPersons(this.$store.state.currentSearch)
+    }
   }
 }
 </script>


### PR DESCRIPTION
Aujourd'hui, quand on se rend sur https://popcorn-nantes.github.io/, on peut observer pendant un court instant que les profils sont dans un certain ordre, avant d'etre écrasé par un autre ordre. 

Ce fix évite ce "repaint" de la page au premier chargement. (régression suite à l'ajout de la fonctionnalité qui permet de conserver la recherche en revenant d'un profil